### PR TITLE
Fail if user could not be deleted

### DIFF
--- a/oracle_user
+++ b/oracle_user
@@ -466,6 +466,8 @@ def main():
             if drop_user(module, msg, cursor, schema):
                 msg = 'The schema (%s) has been dropped successfully' % schema
                 module.exit_json(msg=msg, changed=True)
+            else:
+                module.fail_json(msg=msg[0], changed=False)
         else:
             module.exit_json(msg='The schema (%s) doesn\'t exist' % schema, changed=False)
 


### PR DESCRIPTION
If the Oracle User could not be deleted (for example because there are still open connections), the module falsely gives a Success-Message. With this PR the Error Message from Oracle will be propagated properly.

Before:
`[16:11:46] oracle : Drop Oracle User [XXX] | XXX | SUCCESS | 926ms`

After:
```
[16:14:42] oracle : Drop Oracle User [XXX] | XXX | FAILED | 1143ms
{
  - msg: Blergh, something went wrong while dropping the schema - ORA-01940: Ein Benutzer, der gerade mit der DB verbunden ist, kann nicht geloscht werden sql: drop user XXX cascade
  - _ansible_parsed: True
  - changed: False
}
```