### PR TITLE
oracle_db: Bufgix for db_unique_name in oracle_db

### DIFF
--- a/oracle_db
+++ b/oracle_db
@@ -444,7 +444,7 @@ def create_db (module, msg, oracle_home, sys_password, system_password, dbsnmp_p
             paramslist = ",".join(initparams)
             initparam += ' %s' % (paramslist)
 
-    if initparam != '-initParams ' and paramslist != "":
+    if initparam != '-initParams ' and (paramslist != "" or db_unique_name != None):
         command += initparam
     #module.exit_json(msg=command, changed=False)
     (rc, stdout, stderr) = module.run_command(command)


### PR DESCRIPTION
The parameter was ignored in some situations.