### PR TITLE
oracle_opatch: Use 'sqlplus -V' instead of just sqlplus when checking…

### DIFF
--- a/oracle_opatch
+++ b/oracle_opatch
@@ -106,7 +106,7 @@ def get_version(module, msg, oracle_home):
     Returns the DB server version
     '''
 
-    command = '%s/bin/sqlplus' % (oracle_home)
+    command = '%s/bin/sqlplus -V' % (oracle_home)
     (rc, stdout, stderr) = module.run_command(command)
     if rc != 0:
         msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)


### PR DESCRIPTION
… version