### PR TITLE
oracle_datapatch: Use 'sqlplus -V' instead of just sqlplus when check…

### DIFF
--- a/oracle_datapatch
+++ b/oracle_datapatch
@@ -83,7 +83,7 @@ else:
 
 
 def get_version(module, msg, oracle_home):
-    command = '%s/bin/sqlplus' % (oracle_home)
+    command = '%s/bin/sqlplus -V' % (oracle_home)
     (rc, stdout, stderr) = module.run_command(command)
     if rc != 0:
         msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)


### PR DESCRIPTION
…ing version