### PR TITLE
oracle_profile: case-insensitive parameter compare

### DIFF
--- a/oracle_profile
+++ b/oracle_profile
@@ -172,7 +172,7 @@ def ensure_profile_state(cursor, module, msg, name, state, attribute_name, attri
     if (attribute_name and attribute_value):
         # Make sure attributes are lower case
         attribute_name =  [x.lower() for x in attribute_name]
-        attribute_value =  [str(y) for y in attribute_value]
+        attribute_value =  [str(y).lower() for y in attribute_value]
         wanted_attributes = zip(attribute_name,attribute_value)
 
         # Check the current attributes


### PR DESCRIPTION
The IS state is grabbed with lowercase parameter values. The SHOULD
state should be lowercased also to ensure we don't try to perform
changes that aren't actually required.