### PR TITLE
oracle_opatch: Changed check against owner in oracle_opatch

### DIFF
--- a/oracle_opatch
+++ b/oracle_opatch
@@ -141,11 +141,11 @@ def get_file_owner(module, msg, oracle_home):
     '''
     This will only be run if opatchauto is True.
     The owner of ORACLE_HOME has to be established, and we do this be checking file
-    ownership on ORACLE_HOME/bin/sqlplus.
+    ownership on ORACLE_HOME/bin/oracle.
     returns the owner
     '''
 
-    checkfile = '%s/bin/sqlplus' % (oracle_home)
+    checkfile = '%s/bin/oracle' % (oracle_home)
     if os.path.exists(checkfile):
         stat_info = os.stat(checkfile)
         uid = stat_info.st_uid


### PR DESCRIPTION
The executable sqlplus is owned by root in GI 18c. It is changed
to the executable oracle which is always owner by the owner of
the GI.

This is the bugfix for #101.