### PR TITLE
Change exception syntax for python3 support

### DIFF
--- a/oracle_awr
+++ b/oracle_awr
@@ -161,7 +161,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)

--- a/oracle_facts
+++ b/oracle_facts
@@ -139,7 +139,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)

--- a/oracle_job
+++ b/oracle_job
@@ -442,7 +442,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)

--- a/oracle_jobclass
+++ b/oracle_jobclass
@@ -178,7 +178,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)

--- a/oracle_jobschedule
+++ b/oracle_jobschedule
@@ -179,7 +179,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)

--- a/oracle_jobwindow
+++ b/oracle_jobwindow
@@ -201,7 +201,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)

--- a/oracle_ldapuser
+++ b/oracle_ldapuser
@@ -206,7 +206,7 @@ def query_ldap_users():
                 users.append(userinfo)
             except:
                 pass
-    except ldap.LDAPError, e:
+    except ldap.LDAPError as e:
         module.fail_json(msg="Error querying LDAP: %s" % e, changed=False)
     return users
 
@@ -256,7 +256,7 @@ def main():
         lconn = ldap.initialize(module.params['ldap_connect'])
         lconn.set_option(ldap.OPT_REFERRALS, 0)
         lconn.simple_bind_s(module.params['ldap_binddn'], module.params['ldap_bindpassword'])
-    except ldap.LDAPError, e:
+    except ldap.LDAPError as e:
         module.fail_json(msg="LDAP connection error: %s" % e)
     lparam = {
         'basedn': module.params['ldap_user_basedn'],
@@ -294,7 +294,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)

--- a/oracle_privs
+++ b/oracle_privs
@@ -264,7 +264,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)

--- a/oracle_rsrc_consgroup
+++ b/oracle_rsrc_consgroup
@@ -325,7 +325,7 @@ def main():
         elif (not(user) or not(password)):
             module.fail_json(msg='Missing username or password for cx_Oracle')
 
-    except cx_Oracle.DatabaseError, exc:
+    except cx_Oracle.DatabaseError as exc:
         error, = exc.args
         msg[0] = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
         module.fail_json(msg=msg[0], changed=False)


### PR DESCRIPTION
When executing some of the modules with python3 we run into errors because the exceptions have invalid syntax for python3.