### PR TITLE
oracle_opatch: Find running listener more robust

### DIFF
--- a/oracle_opatch
+++ b/oracle_opatch
@@ -315,7 +315,8 @@ def stop_process(module, oracle_home):
                elif len(line.split(':')) >= 2 and line.split(':')[1] == oracle_home:
 
                    # Find listener for ORACLE_HOME
-                   p = subprocess.Popen('ps -elf| grep "[0-9] %s/bin/tnslsnr"' % (line.split(':')[1]) , shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                   tnslsnr = "%s/bin/tnslsnr" % (line.split(':')[1])
+                   p = subprocess.Popen('ps -elf| grep "[0-9] %s"' % tnslsnr, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                    output, error = p.communicate()
                    p_status = p.wait()
 
@@ -324,7 +325,7 @@ def stop_process(module, oracle_home):
 
                            linelist = lline.split(' ')
                            if len(lline) > 3:
-                               listener_name = linelist[-2]
+                               listener_name = linelist[linelist.index(tnslsnr) + 1]
                                lsnrctl_bin = '%s/bin/lsnrctl' % (oracle_home)
                                try:
                                    p = subprocess.check_call([lsnrctl_bin, 'stop', '%s' % listener_name])

--- a/oracle_opatch
+++ b/oracle_opatch
@@ -337,7 +337,7 @@ def stop_process(module, oracle_home):
                    if msg:
                        module.fail_json(msg=msg, changed=False)
 
-def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, ocm_response_file,output):
+def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, ocm_response_file, stop_processes, output):
     '''
     Removes the patch
     '''
@@ -350,6 +350,9 @@ def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, oc
 
         command = '%s/OPatch/%s %s -oh %s ' % (oracle_home,opatch_cmd, patch_base, oracle_home)
     else:
+        if stop_processes:
+            stop_process(module, oracle_home)
+
         opatch_cmd = 'opatch rollback'
         command = '%s/OPatch/%s -id %s -silent' % (oracle_home,opatch_cmd, patch_id)
 
@@ -543,7 +546,7 @@ def main():
 
     elif state == 'absent':
         if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
-            if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, output):
+            if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, stop_processes, output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully removed from %s' % (patch_id,patch_version, oracle_home)
                 else:

--- a/oracle_opatch
+++ b/oracle_opatch
@@ -37,6 +37,15 @@ options:
         required: False
         default: None
         aliases: ['version_added']
+    exclude_upi:
+        description:
+            - The unique patch identifier that should not be rolled back
+              e.g 22990084
+            - This option will be honored only when state=absent.
+            - It helps to write idempotent playbooks when changing interim patches that are dependent on a specific PSU/RU.
+        required: False
+        default: None
+        aliases: ['exclude_unique_patch_id']
     opatch_minversion:
         description:
             - The minimum version of opatch needed
@@ -155,7 +164,7 @@ def get_file_owner(module, msg, oracle_home):
         msg = 'Could not determine owner of %s ' % (checkfile)
         module.fail_json(msg=msg)
 
-def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, exclude_upi):
     '''
     Gets all patches already applied and compares to the
     intended patch
@@ -169,8 +178,8 @@ def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatc
     (rc, stdout, stderr) = module.run_command(command)
     #module.exit_json(msg=stdout, changed=False)
     if rc != 0:
-      msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
-      module.fail_json(msg=msg, changed=False)
+        msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
+        module.fail_json(msg=msg, changed=False)
     else:
         if opatchauto:
             chk = '%s' % (patch_version)
@@ -180,7 +189,17 @@ def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatc
             chk = '%s' % (patch_id)
 
         if chk in stdout:
-            return True
+            if exclude_upi is None:
+                return True
+            else:
+                command += ' -id %s' % patch_id
+                (rc, stdout, stderr) = module.run_command(command)
+                if rc != 0:
+                    msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
+                    module.fail_json(msg=msg, changed=False)
+                else:
+                    chk = 'unique_patch_id:%s' % exclude_upi
+                    return (chk not in stdout)
         else:
             return False
 
@@ -446,6 +465,7 @@ def main():
             patch_base          = dict(default=None, aliases = ['path','source','patch_source','phBaseDir']),
             patch_id            = dict(default=None, aliases = ['id']),
             patch_version       = dict(required=None, aliases = ['version']),
+            exclude_upi         = dict(required=None, aliases = ['exclude_unique_patch_id']),
             opatch_minversion   = dict(default=None, aliases = ['opmv']),
             opatchauto          = dict(default='False', type='bool',aliases = ['autopatch']),
             rolling             = dict(default='True', type='bool',aliases = ['rolling']),
@@ -457,7 +477,7 @@ def main():
             output              = dict(default="short", choices = ["short","verbose"]),
             state               = dict(default="present", choices = ["present", "absent", "opatchversion"]),
             hostname            = dict(required=False, default = 'localhost', aliases = ['host']),
-            port                = dict(required=False, default = 1521),
+            port                = dict(required=False, type='int', default = 1521),
 
 
 
@@ -469,6 +489,7 @@ def main():
     patch_base          = module.params["patch_base"]
     patch_id            = module.params["patch_id"]
     patch_version       = module.params["patch_version"]
+    exclude_upi         = module.params["exclude_upi"]
     opatch_minversion   = module.params["opatch_minversion"]
     opatchauto          = module.params["opatchauto"]
     rolling             = module.params["rolling"]
@@ -529,7 +550,7 @@ def main():
         module.exit_json(msg=opatch_version,changed=False)
 
     if state == 'present':
-        if not check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+        if not check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, None):
             if apply_patch(module, msg, oracle_home, patch_base, patch_id,patch_version, opatchauto,ocm_response_file,offline,stop_processes,rolling,output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully applied to %s' % (patch_id,patch_version, oracle_home)
@@ -545,7 +566,7 @@ def main():
             module.exit_json(msg=msg, changed=False)
 
     elif state == 'absent':
-        if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+        if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, exclude_upi):
             if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, stop_processes, output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully removed from %s' % (patch_id,patch_version, oracle_home)
@@ -556,8 +577,9 @@ def main():
                 module.fail_json(msg=msg, changed=False)
         else:
             if patch_version is not None:
-                msg = 'Patch %s (%s) is not applied to %s' % (patch_id,patch_version, oracle_home)
-
+                msg = 'Patch %s (%s) is not applied to %s' % (patch_id, patch_version, oracle_home)
+            elif exclude_upi is not None:
+                msg = 'Patch %s (UPI %s) has already been applied and will not be removed from %s' % (patch_id, exclude_upi, oracle_home)
             else:
                 msg = 'Patch %s is not applied to %s' % (patch_id, oracle_home)
 


### PR DESCRIPTION
This PR should contain commit 42e65ec only. But it includes other unrelated commits.

This is the commit message:

Oracle_opatch searches the running listener with:

```ps -elf | grep "[0-9] $ORACLE_HOME/bin/tnslsnr"```

...then splits the line by spaces and takes the last but one field.
This does not work for a "ps -ef" result like this:

```0 S oracle   16921     1  0  80   0 - 43851 ep_pol 21:58 ?        00:00:00 /u01/app/oracle/product/12.1.0.2/ee/bin/tnslsnr LISTENER /dev/null -inherit```

In this case "linelist[-2]" deliveres "/dev/null" instead of the LISTENER
name. My fix is to search the ps line for the listener executable and use
the next field.