### PR TITLE
New module oracle_sqldba for "sqlplus / as sysdba" and catcon.pl

### DIFF
--- a/oracle_opatch
+++ b/oracle_opatch
@@ -315,7 +315,8 @@ def stop_process(module, oracle_home):
                elif len(line.split(':')) >= 2 and line.split(':')[1] == oracle_home:
 
                    # Find listener for ORACLE_HOME
-                   p = subprocess.Popen('ps -elf| grep "[0-9] %s/bin/tnslsnr"' % (line.split(':')[1]) , shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                   tnslsnr = "%s/bin/tnslsnr" % (line.split(':')[1])
+                   p = subprocess.Popen('ps -elf| grep "[0-9] %s"' % tnslsnr, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                    output, error = p.communicate()
                    p_status = p.wait()
 
@@ -324,7 +325,7 @@ def stop_process(module, oracle_home):
 
                            linelist = lline.split(' ')
                            if len(lline) > 3:
-                               listener_name = linelist[-2]
+                               listener_name = linelist[linelist.index(tnslsnr) + 1]
                                lsnrctl_bin = '%s/bin/lsnrctl' % (oracle_home)
                                try:
                                    p = subprocess.check_call([lsnrctl_bin, 'stop', '%s' % listener_name])

--- a/oracle_opatch
+++ b/oracle_opatch
@@ -337,7 +337,7 @@ def stop_process(module, oracle_home):
                    if msg:
                        module.fail_json(msg=msg, changed=False)
 
-def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, ocm_response_file,output):
+def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, ocm_response_file, stop_processes, output):
     '''
     Removes the patch
     '''
@@ -350,6 +350,9 @@ def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, oc
 
         command = '%s/OPatch/%s %s -oh %s ' % (oracle_home,opatch_cmd, patch_base, oracle_home)
     else:
+        if stop_processes:
+            stop_process(module, oracle_home)
+
         opatch_cmd = 'opatch rollback'
         command = '%s/OPatch/%s -id %s -silent' % (oracle_home,opatch_cmd, patch_id)
 
@@ -543,7 +546,7 @@ def main():
 
     elif state == 'absent':
         if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
-            if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, output):
+            if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, stop_processes, output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully removed from %s' % (patch_id,patch_version, oracle_home)
                 else:

--- a/oracle_opatch
+++ b/oracle_opatch
@@ -37,6 +37,15 @@ options:
         required: False
         default: None
         aliases: ['version_added']
+    exclude_upi:
+        description:
+            - The unique patch identifier that should not be rolled back
+              e.g 22990084
+            - This option will be honored only when state=absent.
+            - It helps to write idempotent playbooks when changing interim patches that are dependent on a specific PSU/RU.
+        required: False
+        default: None
+        aliases: ['exclude_unique_patch_id']
     opatch_minversion:
         description:
             - The minimum version of opatch needed
@@ -155,7 +164,7 @@ def get_file_owner(module, msg, oracle_home):
         msg = 'Could not determine owner of %s ' % (checkfile)
         module.fail_json(msg=msg)
 
-def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, exclude_upi):
     '''
     Gets all patches already applied and compares to the
     intended patch
@@ -169,8 +178,8 @@ def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatc
     (rc, stdout, stderr) = module.run_command(command)
     #module.exit_json(msg=stdout, changed=False)
     if rc != 0:
-      msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
-      module.fail_json(msg=msg, changed=False)
+        msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
+        module.fail_json(msg=msg, changed=False)
     else:
         if opatchauto:
             chk = '%s' % (patch_version)
@@ -180,7 +189,17 @@ def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatc
             chk = '%s' % (patch_id)
 
         if chk in stdout:
-            return True
+            if exclude_upi is None:
+                return True
+            else:
+                command += ' -id %s' % patch_id
+                (rc, stdout, stderr) = module.run_command(command)
+                if rc != 0:
+                    msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
+                    module.fail_json(msg=msg, changed=False)
+                else:
+                    chk = 'unique_patch_id:%s' % exclude_upi
+                    return (chk not in stdout)
         else:
             return False
 
@@ -446,6 +465,7 @@ def main():
             patch_base          = dict(default=None, aliases = ['path','source','patch_source','phBaseDir']),
             patch_id            = dict(default=None, aliases = ['id']),
             patch_version       = dict(required=None, aliases = ['version']),
+            exclude_upi         = dict(required=None, aliases = ['exclude_unique_patch_id']),
             opatch_minversion   = dict(default=None, aliases = ['opmv']),
             opatchauto          = dict(default='False', type='bool',aliases = ['autopatch']),
             rolling             = dict(default='True', type='bool',aliases = ['rolling']),
@@ -457,7 +477,7 @@ def main():
             output              = dict(default="short", choices = ["short","verbose"]),
             state               = dict(default="present", choices = ["present", "absent", "opatchversion"]),
             hostname            = dict(required=False, default = 'localhost', aliases = ['host']),
-            port                = dict(required=False, default = 1521),
+            port                = dict(required=False, type='int', default = 1521),
 
 
 
@@ -469,6 +489,7 @@ def main():
     patch_base          = module.params["patch_base"]
     patch_id            = module.params["patch_id"]
     patch_version       = module.params["patch_version"]
+    exclude_upi         = module.params["exclude_upi"]
     opatch_minversion   = module.params["opatch_minversion"]
     opatchauto          = module.params["opatchauto"]
     rolling             = module.params["rolling"]
@@ -529,7 +550,7 @@ def main():
         module.exit_json(msg=opatch_version,changed=False)
 
     if state == 'present':
-        if not check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+        if not check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, None):
             if apply_patch(module, msg, oracle_home, patch_base, patch_id,patch_version, opatchauto,ocm_response_file,offline,stop_processes,rolling,output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully applied to %s' % (patch_id,patch_version, oracle_home)
@@ -545,7 +566,7 @@ def main():
             module.exit_json(msg=msg, changed=False)
 
     elif state == 'absent':
-        if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+        if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, exclude_upi):
             if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, stop_processes, output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully removed from %s' % (patch_id,patch_version, oracle_home)
@@ -556,8 +577,9 @@ def main():
                 module.fail_json(msg=msg, changed=False)
         else:
             if patch_version is not None:
-                msg = 'Patch %s (%s) is not applied to %s' % (patch_id,patch_version, oracle_home)
-
+                msg = 'Patch %s (%s) is not applied to %s' % (patch_id, patch_version, oracle_home)
+            elif exclude_upi is not None:
+                msg = 'Patch %s (UPI %s) has already been applied and will not be removed from %s' % (patch_id, exclude_upi, oracle_home)
             else:
                 msg = 'Patch %s is not applied to %s' % (patch_id, oracle_home)
 

--- a/oracle_sqldba
+++ b/oracle_sqldba
@@ -1,0 +1,375 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: oracle_sqldba
+short_description: Execute sql (scripts) using sqlplus (BEQ) or catcon.pl
+description:
+    - Needed for post-installation tasks not covered by other modules
+    - Uses sqlplus (BEQ connect, e.g. / as sysdba) or $OH//perl catcon.pl
+options:
+    sql:
+        description:
+            - Single SQL statement
+            - Will be executed by sqlplus
+            - Used for DDL and DML
+        required: false
+        default: None
+    sqlscript:
+        description:
+            - Script name, optionally followed by parameters
+            - Will be executed by sqlplus
+        required: false
+        default: None
+    catcon_pl:
+        description:
+            - Script name, optionally followed by parameters
+            - Will be executed by $OH//perl catcon.pl
+        required: false
+        default: None
+    sqlselect:
+        description:
+            - Single SQL statement
+            - Will be executed by sqlplus using dbms_xmlgen.getxml
+            - Used for select only, returns dict in .state
+            - To access the column "value" of the first row write: "<<registered result>>.state.ROW[0].VALUE" (use uppercase)
+        required: false
+        default: None
+    creates_sql:
+        description:
+            - This is the check query to ensure idempotence.
+            - Must be a single SQL select that results to no rows or a plain 0 if the catcon_pl/sqlscript/sql has to be executed. Any other result let the catcon_pl/sqlscript/sql execute.
+            - The catcon_pl/sqlscript/sql will be executed unconditionally if creates_sql is omitted.
+            - Creates_sql must be omitted when sqlselect is used.
+            - Creates_sql is executed with sqlplus / as sysdba in the root container. Write the sql query according to this fact.
+        required: false
+        default: None
+    username:
+        description:
+            - Database username, defaults to "/ as sysdba"
+        required: false
+        default: None
+    password:
+        description:
+            - Password of database user
+        required: false
+        default: None
+    scope:
+        description:
+            - Shall the SQL be applied to CDB, PDBs, or both?
+        values:
+            - default: if catcon_pl is filled then all_pdbs else cdb
+            - db: alias for cdb, allows for better readability for non-cdb
+            - cdb: apply to root container or whole db
+            - pdbs: apply to specified PDB's only (requires pdb_list)
+            - all_pdbs: apply to all PDB's except PDB$SEED
+        required: false
+        default: cdb
+    pdb_list:
+        description:
+            - Optional list of PDB names
+            - Space separated, as catcon.pl wants
+            - Gets used only if scope is "pdbs"
+        required: false
+        default: None
+    oracle_home:
+        description:
+            - content of $ORACLE_HOME
+    oracle_db_name:
+        description:
+            - SID or DB_NAME, needed for BEQ connect
+author: Dietmar Uhlig, Robotron (www.robotron.de)
+'''
+
+EXAMPLES = '''
+# Example 1, mixed post installation tasks
+# from inventory:
+
+oracle_databases:
+  - oracle_db_name: eek17ec
+      home: 12.2.0.1-ee
+      state: present
+      init_parameters: "{{ init_parameters['12.2.0.1-EMS'] }}"
+      profiles: "{{ db_profiles['12.2.0.1-EMS'] }}"
+      postinstall: "{{ db_postinstall['12.2.0.1-EMS'] }}"
+
+oracle_pdbs:
+  - cdb: eek17ec
+    pdb_name: eckpdb
+  - cdb: eek17ec
+    pdb_name: sckpdb
+
+db_postinstall:
+  12.2.0.1-EMS:
+    - catcon_pl: "$ORACLE_HOME/ctx/admin/catctx.sql context SYSAUX TEMP NOLOCK"
+      creates_sql: "select 1 from dba_registry where comp_id = 'CONTEXT'"
+    - sqlscript: "?/rdbms/admin/initsqlj.sql"
+      scope: pdbs
+      creates_sql: "select count(*) from dba_tab_privs where table_name = 'SQLJUTL' and grantee = 'PUBLIC'"
+    - sqlscript: "?/rdbms/admin/utlrp.sql"
+    - sql: "alter pluggable database {{ pdb.pdb_name | default(omit) }} save state"
+      scope: pdbs
+
+# see role oradb-postinstall, loops over {{ oracle_databases }} = loop_var oradb
+
+- name: Conditionally execute post installation tasks
+  oracle_sqldba:
+    sql: "{{ pitask.sql | default(omit) }}"
+    sqlscript: "{{ pitask.sqlscript | default(omit) }}"
+    catcon_pl: "{{ pitask.catcon_pl | default(omit) }}"
+    creates_sql: "{{ pitask.creates_sql | default(omit) }}"
+    username: "{{ pitask.username | default(omit) }}"
+    password: "{%if pitask.username is defined%}{{ dbpasswords[oradb.oracle_db_name][pitask.username] }}{%endif%}"
+    scope: "{{ pitask.scope | default(omit) }}"
+    pdb_list: "{{ oracle_pdbs | default([]) | json_query('[?cdb==`' + oradb.oracle_db_name + '`].pdb_name') | join(' ') }}"
+    oracle_home: "{{ db_homes_config[oradb.home].oracle_home }}"
+    oracle_db_name: "{{ oradb.oracle_db_name }}"
+  loop: "{{ oradb.postinstall }}"
+  loop_control:
+    loop_var: pitask
+
+# Example 2, read sql result
+
+- name: Read job_queue_processes
+  oracle_sqldba:
+    sqlselect: "select value from gv$parameter where name = 'job_queue_processes'"
+    oracle_home: "{{ oracle_db_home }}"
+    oracle_db_name: "{{ oracle_db_name }}"
+  register: jqpresult
+
+- name: Store job_queue_processes
+  set_fact:
+    job_queue_processes: "{{ jqpresult.state.ROW[0].VALUE }}"
+    # Use all uppercase for "ROW" and for column names!
+
+'''
+
+import errno
+import os
+import re
+import shlex
+import shutil
+from subprocess import Popen, PIPE
+import tempfile
+from threading import Timer
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native, to_text
+import xml.etree.ElementTree as ET
+from copy import copy
+
+changed = False
+result = ""
+err_msg = None
+oracle_home = ""
+
+# Maximum runtime for sqlplus and catcon.pl in seconds. 0 means no timeout.
+timeout = 900
+
+# dictify is based on https://stackoverflow.com/questions/2148119/how-to-convert-an-xml-string-to-a-dictionary/10077069#10077069
+def dictify(r,root=True):
+    if root:
+        #return {r.tag : dictify(r, False)} # no, but...
+        return dictify(r, False) # skip root node "ROWSET"
+    d=copy(r.attrib)
+    if (r.text).strip():
+        d["_text"]=r.text
+    for x in r.findall("./*"):
+        if x.tag not in d:
+            d[x.tag]=[]
+        if (x.text).strip(): # assume scalar
+            d[x.tag] = x.text
+        else:
+            d[x.tag].append(dictify(x,False))
+    return d
+
+def sqlplus():
+    global oracle_home
+
+    sql_bin = os.path.join(oracle_home, "bin", "sqlplus")
+    return [sql_bin, "-l", "-s", "/nolog"]
+
+def conn(username, password):
+    if username == None:
+        return "conn / as sysdba\n"
+    else:
+        return "conn " + "/".join([username, password]) + "\n"
+
+def sql_input(sql, username, password, scope, pdb_list):
+    sql_scr  = "set heading off echo off feedback off termout on\n"
+    sql_scr += "set long 1000000 pagesize 0 linesize 1000 trimspool on\n"
+    sql_scr += conn(username, password)
+
+    if scope == 'pdbs':
+        sql_scr += "whenever sqlerror exit\n"
+        for pdb in pdb_list.split():
+            sql_scr += "alter session set container = " + pdb + ";\n"
+            sql_scr += sql + "\n"
+    else:
+        sql_scr += sql + "\n"
+    sql_scr += "exit;\n"
+    return sql_scr
+
+def run_sql(sql, username, password, scope, pdb_list):
+    global changed, err_msg
+
+    t = None
+    try:
+        sql_cmd = sql_input(sql, username, password, scope, pdb_list)
+        p = Popen(sqlplus(), stdin = PIPE, stdout = PIPE, stderr = PIPE)
+        if timeout > 0:
+            t = Timer(timeout, p.kill)
+            t.start()
+        [sout, serr] = p.communicate(input = sql_cmd)
+    except Exception as e:
+        err_msg = 'Could not call sqlplus. %s. called: %s.' % (to_native(e), sql_cmd)
+        return "ERR"
+    finally:
+        if timeout > 0 and t is not None:
+            t.cancel()
+    if p.returncode != 0:
+        err_msg = "called: " + sql_cmd + "\nresult: " + sout + ". stderr = " + serr + "."
+        return "ERR"
+    sqlplus_err = re.compile("^(ORA|TNS|SP2)-", re.MULTILINE)
+    if sqlplus_err.search(sout):
+        err_msg = "sqlplus# " + sql_cmd + ": " + sout + "."
+        return "ERR"
+
+    changed = True
+    return sout.strip()
+
+
+def check_creates_sql(sql):
+    global result
+
+    if not sql.endswith(";"):
+        sql += ";"
+    result = run_sql(sql, None, None, None, None)
+    return False if not result or result == "0" else True
+
+
+def run_catcon_pl(catcon_pl, scope, pdb_list):
+    # after pre-processing in main() the parameter scope is not necessary any more
+    global oracle_home, changed, result, err_msg
+
+    catcon_pl = re.sub("^(\$ORACLE_HOME|\?)", oracle_home, catcon_pl)
+    logdir = tempfile.mkdtemp()
+    catcon_cmd = [ os.path.join(oracle_home, "perl", "bin", "perl"),
+                   os.path.join(oracle_home, "rdbms", "admin", "catcon.pl"),
+                   "-l", logdir, "-b", "catcon" ]
+    if pdb_list is not None:
+        catcon_cmd += [ "-c", pdb_list ]
+    cc_script = shlex.split(catcon_pl)
+    if len(cc_script) > 1:
+        for i in range(1, len(cc_script)):
+            cc_script[i] = "1" + cc_script[i]
+        catcon_cmd += [ "-a", "1" ]
+    catcon_cmd += [ "--" ] + cc_script
+    try:
+        p = Popen(catcon_cmd, stdout = PIPE, stderr = PIPE)
+        if timeout > 0:
+            t = Timer(timeout, p.kill)
+            t.start()
+        [sout, serr] = p.communicate()
+    except Exception as e:
+        err_msg = 'Could not call perl. %s. called: %s.' % (to_native(e), " ".join(catcon_cmd))
+        return
+    finally:
+        if timeout > 0:
+            t.cancel()
+        try:
+            shutil.rmtree(logdir)
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                raise
+    if p.returncode != 0:
+        err_msg = "called: " + " ".join(catcon_cmd) + "\nresult: " + sout + ".\nstderr = " + serr + "."
+        return
+    result = sout
+    changed = True
+
+
+
+def main():
+    global oracle_home
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            sql            = dict(required = False),
+            sqlscript      = dict(required = False),
+            catcon_pl      = dict(required = False),
+            sqlselect      = dict(required = False),
+            creates_sql    = dict(required = False),
+            username       = dict(required = False),
+            password       = dict(required = False, no_log = True),
+            scope          = dict(required = False, choices = ["default", "db", "cdb", "pdbs", "all_pdbs"], default = 'default'),
+            pdb_list       = dict(required = False),
+            oracle_home    = dict(required = True),
+            oracle_db_name = dict(required = True)
+        ),
+        mutually_exclusive=[['sql', 'sqlscript', 'catcon_pl', 'sqlselect'], ['sqlselect', 'creates_sql']]
+    )
+
+    sql            = module.params["sql"]
+    sqlscript      = module.params["sqlscript"]
+    catcon_pl      = module.params["catcon_pl"]
+    sqlselect      = module.params["sqlselect"]
+    creates_sql    = module.params["creates_sql"]
+    username       = module.params["username"]
+    password       = module.params["password"]
+    scope          = module.params["scope"]
+    pdb_list       = module.params["pdb_list"]
+    oracle_home    = module.params["oracle_home"]
+    oracle_db_name = module.params["oracle_db_name"]
+
+    os.environ["ORACLE_HOME"] = oracle_home
+    os.environ["ORACLE_SID"] = oracle_db_name
+    os.environ["PATH"] += os.pathsep + os.path.join(oracle_home, "bin")
+
+    if scope == 'db':
+        scope = 'cdb'
+    if scope == 'default':
+        scope = "all_pdbs" if catcon_pl is not None else "cdb"
+    if scope == 'pdbs' and pdb_list.strip() == "":
+        module.exit_json(msg = "scope = pdbs, but pdb_list is empty", changed = False)
+    if scope == 'cdb' and catcon_pl is not None:
+        scope = pdbs
+        pdb_list = 'CDB$ROOT'
+    if scope == 'all_pdbs' and catcon_pl is None:
+        module.fail_json(msg = "scope = all_pdbs not implemented for sql, sqlscript, and sqlselect", changed = False)
+
+    if creates_sql is not None:
+        already_done = check_creates_sql(creates_sql)
+        if err_msg:
+            module.fail_json(msg = err_msg, changed = False)
+        else:
+            if already_done:
+                module.exit_json(msg = result, changed = False)
+
+    if sqlselect is not None:
+        if sqlselect.endswith(";"):
+            sqlselect.rstrip(";")
+        sqlselect = "select dbms_xmlgen.getxml('" + sqlselect.replace("'", "''") + "') from dual;"
+        run_sql(sqlselect, username, password, scope, pdb_list)
+    elif sql is not None:
+        if not sql.endswith(";"):
+            sql += ";"
+        run_sql(sql, username, password, scope, pdb_list)
+    elif sqlscript is not None:
+        if not sqlscript.startswith("@"):
+            sqlscript = "@" + sqlscript
+        run_sql(sqlscript, username, password, scope, pdb_list)
+    elif catcon_pl is not None:
+        run_catcon_pl(catcon_pl, scope, pdb_list)
+
+    if not err_msg:
+        if sqlselect is not None:
+            module.exit_json(msg = result, changed = False, state = dictify(ET.fromstring(result)))
+        else:
+            module.exit_json(msg = result, changed = changed)
+    else:
+        module.fail_json(msg = err_msg, changed = False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR should contain commit 031b16a only. But it contains other unrelated commits covered by PR #122 and #123. Sorry for that.

There were some requests for oracle_sql connecting password-less, i.e. "/ as sysdba". I see these requests in a wider context. I needed to group post-installation (and up to DB 12.1 also post-patch) tasks. They are a mixture of sql scripts, sql commands, and catcon calls. So I created a new module "oracle_sqldba". This module contains a loosely related feature: to execute a sql query and return the results in a python dict. Examples are in the module's comments section.

The module definitely needs testing. But at least it workes for my purposes.