### PR TITLE
oracle_parameter: Fix reset_parameter definition to match invocation

### DIFF
--- a/oracle_parameter
+++ b/oracle_parameter
@@ -179,7 +179,7 @@ def clean_string(item):
 
     return item
 
-def reset_parameter(module, mode, msg, cursor, name, value, scope, sid):
+def reset_parameter(module, mode, msg, cursor, name, value, comment, scope, sid):
 
     starters = ('+','_','"','"_')
     if not(name):


### PR DESCRIPTION
reset_parameter is now having the same arguments as modify_parameter

Fixes the following error:
```
TypeError: reset_parameter() takes exactly 8 arguments (9 given)
```