### PR TITLE
oracle_user: re-add grants option handling that was (mistakenly?) removed

### DIFF
--- a/oracle_user
+++ b/oracle_user
@@ -193,6 +193,12 @@ def create_user(module, msg, cursor, schema, schema_password, schema_password_ha
 
 	total_sql.append(sql)
 
+	if grants:
+		sql = 'grant %s to %s' % (','.join(clean_list(grants)), schema)
+		if container:
+			sql += ' container = %s' % (container)
+		total_sql.append(sql)
+
 	if container_data:
 		altersql = 'alter user %s set container_data=%s container=current' % (schema, container)
 		total_sql.append(altersql)


### PR DESCRIPTION
I don't know why but commit https://github.com/oravirt/ansible-oracle-modules/commit/ebe743447d7ffd71716d078acf7e30512e1238a8#diff-480f28d8e7311aa806640876f6d04ac2L199 ("Lots of changes") effectively made `grants` option of `oracle_user` inoperable.

This commit re-enables broken functionality.