### PR TITLE
fixed db_domain handling

### DIFF
--- a/oracle_db
+++ b/oracle_db
@@ -377,7 +377,7 @@ def create_db (module, msg, oracle_home, sys_password, system_password, dbsnmp_p
 			initparam += 'db_name=%s,db_unique_name=%s,' % (db_name,db_unique_name)
 
 		if domain is not None:
-			initparam += 'db_domain=%s' % domain
+			initparam += 'db_domain=%s,' % domain
 
 		if initparams is not None:
 			paramslist = ",".join(initparams)


### PR DESCRIPTION
Please merge this small fix. Using db_domain would leave init_params without comma at the end, leading to problems if initparams were specified as the first parameter would be appended to the domain name.