### PR TITLE
oracle_user fixes

### DIFF
--- a/oracle_grants
+++ b/oracle_grants
@@ -99,214 +99,200 @@ else:
 
 def clean_string(item):
     item = item.replace("'","").replace(", ",",").lstrip(" ").rstrip(",").replace("[","").replace("]","")
-
     return item
+
 
 def clean_list(item):
     item = [p.replace("'","").replace(", ",",").lstrip(" ").rstrip(",").replace("[","").replace("]","") for p in item]
-
     return item
-
 
 
 # Check if the user/schema exists
 def check_user_exists(module, msg, cursor, schema):
-
-    if not(schema):
+    if not schema:
         module.fail_json(msg='Error: Missing schema name (User)', changed=False)
         return False
 
     schema = clean_string(schema)
     sql = 'select count(*) from dba_users where username = upper(\'%s\')' % schema
-
-
     try:
             cursor.execute(sql)
             result = cursor.fetchone()[0]
     except cx_Oracle.DatabaseError as exc:
             error, = exc.args
-            msg = error.message+ 'sql: ' + sql
-            return False
+            msg = error.message+ ' sql: ' + sql
+            module.fail_json(msg=msg, changed=False)
 
     if result > 0:
         return True
-    else:
-        msg = 'User doesn\'t exist'
-        return False
+    msg = "User doesn't exist"
+    module.fail_json(msg=msg, changed=False)
+
 
 # Check if the user/role exists
 def check_role_exists(module, msg, cursor, role):
-
-    if not(role):
+    if not role:
         module.fail_json(msg='Error: Missing role name', changed=False)
         return False
 
     role = clean_string(role)
-    sql = 'select role from dba_roles where role = upper(\'%s\')' % role
-
-
+    sql = 'select count(*) from dba_roles where role = upper(\'%s\')' % role
     try:
             cursor.execute(sql)
-            result = (cursor.fetchone())
+            result = cursor.fetchone()[0]
     except cx_Oracle.DatabaseError as exc:
             error, = exc.args
-            msg = error.message+ 'sql: ' + sql
-            return False
+            msg = error.message+ ' sql: ' + sql
+            module.fail_json(msg=msg, changed=False)
 
     if result > 0:
-        #module.exit_json(msg='(role) sql %s'% sql, changed=False)
         return True
-    else:
-        msg = 'Role doesn\'t exist'
-        return False
+    msg = "Role doesn't exist"
+    module.fail_json(msg=msg, changed=False)
 
-def get_dir_privs(module, msg, cursor, schema, directory_privs, grants_mode):
+
+def get_dir_priv_sqls(module, msg, cursor, schema, directory_privs, mode):
+    DirPrivilege = namedtuple('DirPrivilege', ['privilege', 'owner', 'directory'])
 
     total_sql_dir = []
     # Directory Privs
+    wanted_dirprivs_set = set()
+    for dp in directory_privs:
+        p = dp.split(':')[0].lower()
+        d = dp.split(':')[1].lower()
+        if '.' in d: # all directories in oracle are owner by SYS by design
+            o = d.split('.')[0]
+            d = d.split('.')[1]
+        else:
+            o = 'sys'
 
-    # module.exit_json(msg=directory_privs)
-    wanted_dirprivs_list = directory_privs
-    w_object_name_l = [w.split(':')[1].lower() for w in wanted_dirprivs_list]
-    w_object_priv_l = [w.split(':')[0].lower() for w in wanted_dirprivs_list]
+        if p == 'all':
+            wanted_dirprivs_set.add(DirPrivilege('read', o, d))
+            wanted_dirprivs_set.add(DirPrivilege('write', o, d))
+            wanted_dirprivs_set.add(DirPrivilege('execute', o, d))
+        else:
+            wanted_dirprivs_set.add(DirPrivilege(p, o, d))
+
+    curr_dir_privs_set = set()
     currdsql_all="""
-    select lower(listagg(p.privilege,',') within group (order by p.privilege) ||':'||p.owner||'.'||p.table_name)
+    select p.privilege, p.owner, p.table_name
     from dba_tab_privs p, dba_objects o
     where p.grantee = upper(\'%s\')
     and p.table_name = o.object_name
     and p.owner = o.owner
     and o.object_type = 'DIRECTORY'
-    group by p.owner,p.table_name
+    order by 2,3,1
     """ % (schema)
-
     result = execute_sql_get(module, msg, cursor, currdsql_all)
+    for r in result:
+        p = r[0].lower()
+        o = r[1].lower()
+        d = r[2].lower()
+        curr_dir_privs_set.add(DirPrivilege(p, o, d))
 
+    unnecessary_dir_privs_set = curr_dir_privs_set.difference()
+    missing_dir_privs_set  = wanted_dirprivs_set.difference(curr_dir_privs_set)
 
-    grant_list_dir = []
-    revoke_list_dir = []
-    current_privs_l = [a[0] for a in result] # Turn list of tuples into list from resultset
-    c_dir_name_l = [ o.split(':')[1].lower() for o in current_privs_l]
-    c_dir_priv_l = [ o.split(':')[0].lower() for o in current_privs_l]
-    remove_completely_dir = set(c_dir_name_l).difference(w_object_name_l)
-    if len(list(remove_completely_dir)) > 0:
-       for remove in list(remove_completely_dir):
-           rdsql = 'revoke all on directory %s from %s' % (remove,schema)
-           revoke_list_dir.append(rdsql)
+    #module.warn("Missing: " + str(missing_dir_privs_set))
+    #module.warn("Unnecessary: " + str(unnecessary_dirprivs_list))
 
-    newstuff = set(w_object_name_l).difference(c_dir_name_l)
-    if len(list(newstuff)) > 0:
-       for index,value in enumerate(w_object_name_l):
-           if value in list(newstuff):
-               nsql = "grant %s on directory %s to %s" % (wanted_dirprivs_list[index].split(':')[0], value, schema)
-               grant_list_dir.append(nsql)
+    if mode == 'REMOVEALL':
+        for p in curr_dir_privs_set:
+            rdsql = "revoke %s on directory %s.%s from %s" % (p.privilege, p.owner, p.directory, schema)
+            total_sql_dir.append(rdsql)
+        return total_sql_dir
 
-    if len(current_privs_l) > 0 and len(wanted_dirprivs_list) > 0:
-       for cp in current_privs_l:
-           object_owner = cp.split(':').pop().split('.')[0]
-           object_name = cp.split(':').pop().split('.')[1]
-           cp_privs = cp.split(':')[0].lower()
-           for wp in wanted_dirprivs_list:
-               wp_object = wp.split(':')[1].lower()
-               if wp.split(':')[1].lower() == cp.split(':')[1].lower(): # Compare object_names
-                   cp_privs = cp.split(':')[0].lower().split(',')
-                   wp_privs = wp.split(':')[0].lower().split(',')
-                   priv_add = set(wp_privs).difference(cp_privs)
-                   priv_revoke = set(cp_privs).difference(wp_privs)
-                   if len(list(priv_add)) > 0:
-                       adsql = "grant %s on directory %s to %s" % (','.join(a for a in priv_add),wp_object,schema)
-                       grant_list_dir.append(adsql)
-                   if len(list(priv_revoke)) > 0:
-                       rdsql = "revoke %s on directory %s from %s" % (','.join(a for a in priv_revoke),wp_object,schema)
-                       revoke_list_dir.append(rdsql)
+    if mode.lower() == 'enforce':
+        for p in unnecessary_dir_privs_set:
+            rdsql = "revoke %s on directory %s.%s from %s" % (p.privilege, p.owner, p.directory, schema)
+            total_sql_dir.append(rdsql)
 
-    if len(grant_list_dir) > 0:
-       for a in grant_list_dir:
-           total_sql_dir.append(a)
-
-    if grants_mode.lower() == 'enforce':
-        if len(revoke_list_dir) > 0:
-           for a in revoke_list_dir:
-               total_sql_dir.append(a)
-    else:
-        pass
+    for p in missing_dir_privs_set:
+        adsql = "grant %s on directory %s.%s to %s" % (p.privilege, p.owner, p.directory, schema)
+        total_sql_dir.append(adsql)
 
     return total_sql_dir
 
 
-def get_obj_privs (module, msg, cursor, schema, object_privs, grants_mode):
+def get_obj_privs (module, msg, cursor, schema, object_privs, mode):
+    ObjPrivilege = namedtuple('ObjPrivilege', ['privilege', 'owner', 'object'])
+
+    default_user = execute_sql_get(module, msg, cursor, 'select user from dual')[0][0].lower()
 
     total_sql_obj = []
     # OBJECT PRIVS
-    wanted_privs_list = object_privs
-    w_object_name_l = [w.split(':')[1].lower() for w in wanted_privs_list]
-    w_object_priv_l = [w.split(':')[0].lower() for w in wanted_privs_list]
+    wanted_obj_privs_set = set()
+    for dp in object_privs:
+        p = dp.split(':')[0].lower()
+        obj = dp.split(':')[1].lower()
+        if '.' in obj: # all directories in oracle are owner by SYS by design
+            o   = obj.split('.')[0]
+            obj = obj.split('.')[1]
+        else:
+            o = default_user
+
+        if p == 'all':
+            wanted_obj_privs_set.add(ObjPrivilege('alter', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('delete', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('index', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('insert', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('select', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('update', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('references', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('read', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('on commit refresh', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('query rewrite', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('debug', o, obj))
+            wanted_obj_privs_set.add(ObjPrivilege('flashback', o, obj))
+        else:
+            wanted_obj_privs_set.add(ObjPrivilege(p, o, obj))
+
+    curr_obj_privs_set = set()
     currsql_all="""
-    select lower(listagg(p.privilege,',') within group (order by p.privilege) ||':'||p.owner||'.'||p.table_name)
+    select p.privilege, p.owner, p.table_name
     from dba_tab_privs p, dba_objects o
     where p.grantee = upper(\'%s\')
     and p.table_name = o.object_name
     and p.owner = o.owner
     and o.object_type not in ('DIRECTORY','TABLE PARTITION','TABLE SUBPARTITION')
-    group by p.owner,p.table_name
+    order by 2,3,1
     """ % (schema)
-
     result = execute_sql_get(module, msg, cursor, currsql_all)
+    for r in result:
+        p = r[0].lower()
+        o = r[1].lower()
+        d = r[2].lower()
+        curr_obj_privs_set.add(ObjPrivilege(p, o, d))
 
+    unnecessary_obj_privs_set = curr_obj_privs_set.difference(wanted_obj_privs_set)
+    missing_obj_privs_set  = wanted_obj_privs_set.difference(curr_obj_privs_set)
 
-    grant_list = []
-    revoke_list = []
-    current_privs_l = [a[0] for a in result] # Turn list of tuples into list from resultset
-    c_object_name_l = [ o.split(':')[1].lower() for o in current_privs_l]
-    c_object_priv_l = [ o.split(':')[0].lower() for o in current_privs_l]
-    remove_completely = set(c_object_name_l).difference(w_object_name_l)
-    if len(list(remove_completely)) > 0:
-        for remove in list(remove_completely):
-            rsql = 'revoke all on %s from %s' % (remove,schema)
-            revoke_list.append(rsql)
+    #module.warn("Missing: " + str(missing_dir_privs_set))
+    #module.warn("Unnecessary: " + str(unnecessary_dir_privs_set))
 
-    newstuff = set(w_object_name_l).difference(c_object_name_l)
-    if len(list(newstuff)) > 0:
-        for index,value in enumerate(w_object_name_l):
-            if value in list(newstuff):
-                nsql = "grant %s on %s to %s" % (wanted_privs_list[index].split(':')[0], value, schema)
-                grant_list.append(nsql)
+    if mode == 'REMOVEALL':
+        for p in curr_obj_privs_set:
+            rdsql = "revoke %s on directory %s.%s from %s" % (p.privilege, p.owner, p.object, schema)
+            total_sql_obj.append(rdsql)
+        return total_sql_obj
 
-    if len(current_privs_l) > 0 and len(wanted_privs_list) > 0:
-        for cp in current_privs_l:
-            object_owner = cp.split(':').pop().split('.')[0]
-            object_name = cp.split(':').pop().split('.')[1]
-            cp_privs = cp.split(':')[0].lower()
-            for wp in wanted_privs_list:
-                wp_object = wp.split(':')[1].lower()
-                if wp.split(':')[1].lower() == cp.split(':')[1].lower(): # Compare object_names
-                    cp_privs = cp.split(':')[0].lower().split(',')
-                    wp_privs = wp.split(':')[0].lower().split(',')
-                    priv_add = set(wp_privs).difference(cp_privs)
-                    priv_revoke = set(cp_privs).difference(wp_privs)
-                    if len(list(priv_add)) > 0:
-                        asql = "grant %s on %s to %s" % (','.join(a for a in priv_add),wp_object,schema)
-                        grant_list.append(asql)
-                    if len(list(priv_revoke)) > 0:
-                        rsql = "revoke %s on %s from %s" % (','.join(a for a in priv_revoke),wp_object,schema)
-                        revoke_list.append(rsql)
+    if mode.lower() == 'enforce':
+        for p in unnecessary_obj_privs_set:
+            rdsql = "revoke %s on %s.%s from %s" % (p.privilege, p.owner, p.object, schema)
+            total_sql_obj.append(rdsql)
 
-    if len(grant_list) > 0:
-        for a in grant_list:
-            total_sql_obj.append(a)
-
-    if grants_mode.lower() == 'enforce':
-        if len(revoke_list) > 0:
-            for a in revoke_list:
-                total_sql_obj.append(a)
-    else:
-        pass
+    for p in missing_obj_privs_set:
+        adsql = "grant %s on %s.%s to %s" % (p.privilege, p.owner, p.object, schema)
+        total_sql_obj.append(adsql)
 
     return total_sql_obj
+
+
 # Add grants to the schema/role
 def ensure_grants(module, msg, cursor, schema, wanted_grants_list, object_privs, directory_privs, grants_mode, container):
-
-    add_sql = ''
-    remove_sql = ''
+    if not schema: # or not(wanted_grants_list):
+        module.fail_json(msg='Error: Missing schema/role name or grants', changed=False)
+        return False
 
     # If no privs are added, we set the 'wanted' lists to be empty.
     if wanted_grants_list is None or wanted_grants_list == ['']:
@@ -317,29 +303,18 @@ def ensure_grants(module, msg, cursor, schema, wanted_grants_list, object_privs,
         directory_privs = []
 
     # This list will hold all grants the user currently has
-    dir_privs = []
-    obj_privs = []
     total_sql=[]
     total_current=[]
 
-    dir_privs = get_dir_privs(module, msg, cursor, schema, directory_privs, grants_mode)
-    if len(dir_privs)>0:
-        for d in dir_privs:
-            total_sql.append(d)
+    dir_privs = get_dir_priv_sqls(module, msg, cursor, schema, directory_privs, grants_mode)
+    total_sql.extend(dir_privs)
 
     obj_privs = get_obj_privs(module, msg, cursor, schema, object_privs, grants_mode)
-    if len(obj_privs)>0:
-        for o in obj_privs:
-            total_sql.append(o)
+    total_sql.extend(obj_privs)
 
-
-    # module.exit_json(msg=total_sql)
+    #module.exit_json(msg=total_sql)
     exceptions_list=['DBA']
     exceptions_priv=['UNLIMITED TABLESPACE']
-
-    if not(schema): # or not(wanted_grants_list):
-        module.fail_json(msg='Error: Missing schema/role name or grants', changed=False)
-        return False
 
     # Strip the list of unnecessary quotes etc
     wanted_grants_list = clean_list(wanted_grants_list)
@@ -365,53 +340,40 @@ def ensure_grants(module, msg, cursor, schema, wanted_grants_list, object_privs,
     # granted -> on the next run, unlimited tablespace is removed from the user
     # since it is not part of the wanted grants.
     # The following removes 'unlimited tablespace' privilege from the grants_to_remove list, if DBA is also granted
-
     if any(x in exceptions_list for x in wanted_grants_list_upper):
         grants_to_remove = [x for x in grants_to_remove if x.upper() not in exceptions_priv]
 
-    # if there are differences, they will be added.
-    if not any(grants_to_add) and not any(grants_to_remove):
-        pass
-        #module.exit_json(msg="Nothing to do", changed=False)
-    else:
-        # Convert the list of grants to a string
-        if any(grants_to_add):
-            grants_to_add = ','.join(grants_to_add)
-            grants_to_add = clean_string(grants_to_add)
-            add_sql += 'grant %s to %s' % (grants_to_add, schema)
-            if container:
-                add_sql += ' container=%s' % (container)
-            total_sql.append(add_sql)
+    # Convert the list of grants to a string
+    if any(grants_to_remove) and grants_mode.lower() == 'enforce':
+        grants_to_remove = ','.join(grants_to_remove)
+        grants_to_remove = clean_string(grants_to_remove)
+        remove_sql = 'revoke %s from %s' % (grants_to_remove, schema)
+        total_sql.append(remove_sql)
 
-
-        if grants_mode.lower() == 'enforce':
-            if any(grants_to_remove):
-                grants_to_remove = ','.join(grants_to_remove)
-                grants_to_remove = clean_string(grants_to_remove)
-                remove_sql += 'revoke %s from %s' % (grants_to_remove, schema)
-                total_sql.append(remove_sql)
-        else:
-            pass
-
+    if any(grants_to_add):
+        grants_to_add = ','.join(grants_to_add)
+        grants_to_add = clean_string(grants_to_add)
+        add_sql = 'grant %s to %s' % (grants_to_add, schema)
+        if container:
+            add_sql += ' container=%s' % (container)
+        total_sql.append(add_sql)
 
     # module.exit_json(msg=total_sql)
-    if len(total_sql) > 0:
-        if ensure_grants_state_sql(module,msg,cursor,total_sql):
-            module.exit_json(msg=total_sql, changed=True)
+    if total_sql:
+        ensure_grants_state_sql(module, msg, cursor,total_sql)
+        module.exit_json(msg=total_sql, changed=True)
     else:
         msg = 'Nothing to do'
         module.exit_json(msg=msg, changed=False)
-    #     return False
-    #return True
+
 
 def ensure_grants_state_sql(module,msg,cursor,total_sql):
-
     for a in total_sql:
         execute_sql(module, msg, cursor, a)
     return True
 
-def execute_sql(module, msg, cursor, sql):
 
+def execute_sql(module, msg, cursor, sql):
     try:
         cursor.execute(sql)
     except cx_Oracle.DatabaseError as exc:
@@ -421,35 +383,41 @@ def execute_sql(module, msg, cursor, sql):
         return False
     return True
 
+
 # Remove grants to the schema
-def remove_grants(module, msg, cursor, schema, remove_grants_list, object_privs, state):
+def remove_grants(module, msg, cursor, schema, system_grants, object_privs, directory_privs, state):
+    total_sql = []
 
-    sql = ''
+    if state == 'REMOVEALL':
+        dir_privs = get_dir_priv_sqls(module, msg, cursor, schema, directory_privs = [], mode='enforce')
+        total_sql.extend(dir_privs)
+    else: # state == 'absent'
+        pass
 
-    # This list will hold all grants/privs the user currently has
-    total_current=[]
-
-    if not(schema) or not(remove_grants_list):
-        module.fail_json(msg='Error: Missing schema name or grants', changed=False)
-        return False
+    if state == 'REMOVEALL':
+        obj_privs = get_obj_privs(module, msg, cursor, schema, object_privs = [], mode='enforce')
+        total_sql.extend(obj_privs)
+    else: # state == 'absent'
+        pass
 
     # Strip the list of unnecessary quotes etc
-    remove_grants_list = clean_list(remove_grants_list)
+    remove_grants_list = clean_list(system_grants)
     schema = clean_string(schema)
+
+    # This list will hold all grants/privs the user currently has
+    total_current=set()
 
     # Get the current role grants for the schema.
     # If any are present, add them to the total
     curr_role_grants=get_current_role_grants(module, msg, cursor, schema)
     if any(curr_role_grants):
-        total_current.extend(curr_role_grants)
+        total_current.update(curr_role_grants)
 
     # Get the current sys privs for the schema
     # If any are present, add them to the total
     curr_sys_grants=get_current_sys_grants(module, msg, cursor, schema)
     if any(curr_sys_grants):
-        total_current.extend(curr_sys_grants)
-
-
+        total_current.update(curr_sys_grants)
 
     # Get the difference between current grants and wanted grants
     grants_to_remove=set(remove_grants_list).intersection(total_current)
@@ -469,7 +437,7 @@ def remove_grants(module, msg, cursor, schema, remove_grants_list, object_privs,
 
     # if there are differences, they will be removed.
     elif not any(grants_to_remove):
-        module.exit_json(msg="The schema/role (%s) doesn\'t have the grant(s) you want to remove" % schema, changed=False)
+        module.exit_json(msg="The schema/role (%s) doesn't have the grant(s) you want to remove" % schema, changed=False)
 
     else:
         # Convert the list of grants to a string & clean it
@@ -477,8 +445,6 @@ def remove_grants(module, msg, cursor, schema, remove_grants_list, object_privs,
         grants_to_remove = clean_string(grants_to_remove)
         sql += 'revoke %s from %s' % (grants_to_remove, schema)
         msg = 'The grant(s) (%s) successfully removed from the schema/role %s' % (grants_to_remove, schema)
-
-
 
         try:
             cursor.execute(sql)
@@ -489,53 +455,43 @@ def remove_grants(module, msg, cursor, schema, remove_grants_list, object_privs,
 
     return True
 
+
 # Get the current role/sys grants
 def get_current_role_grants(module, msg, cursor, schema):
-
-    curr_role_grants=[]
-
+    curr_role_grants=set()
     sql = 'select granted_role from dba_role_privs where grantee = upper(\'%s\') '% schema
-
-
     try:
             cursor.execute(sql)
             result = cursor.fetchall()
     except cx_Oracle.DatabaseError as exc:
             error, = exc.args
             msg = error.message+ 'sql: ' + sql
-            return False
-    #if result > 0:
-    for item in result:
-        curr_role_grants.append(item[0].lower())
+            module.fail_json(msg=msg, changed=False)
 
+    for item in result:
+        curr_role_grants.add(item[0].lower())
 
     return curr_role_grants
 
+
 # Get the current sys grants
 def get_current_sys_grants(module, msg, cursor, schema):
-
-    curr_sys_grants=[]
-
+    curr_sys_grants=set()
     sql = 'select privilege from dba_sys_privs where grantee = upper(\'%s\') '% schema
-
-
     try:
             cursor.execute(sql)
             result = cursor.fetchall()
     except cx_Oracle.DatabaseError as exc:
             error, = exc.args
             msg = error.message+ 'sql: ' + sql
-            return False
-    #if result > 0:
+            module.fail_json(msg=msg, changed=False)
+
     for item in result:
-        curr_sys_grants.append(item[0].lower())
-
-
+        curr_sys_grants.add(item[0].lower())
     return curr_sys_grants
 
 
 def execute_sql_get(module, msg, cursor, sql):
-
     try:
         cursor.execute(sql)
         result = (cursor.fetchall())
@@ -547,22 +503,21 @@ def execute_sql_get(module, msg, cursor, sql):
     return result
 
 
-
 def main():
-
     msg = ['']
     module = AnsibleModule(
         argument_spec = dict(
+            oracle_home   = dict(required=False, aliases=['oh']),
             hostname      = dict(default='localhost'),
-            port          = dict(default=1521),
-            service_name  = dict(required=True),
+            port          = dict(default=1521, type="int"),
+            service_name  = dict(required=False),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"]),
             schema        = dict(default=None),
             role          = dict(default=None),
-            grants         = dict(default=None, type="list"),
-            object_privs   = dict(default=None, type="list",aliases=['objprivs']),
+            grants        = dict(default=None, type="list"),
+            object_privs  = dict(default=None, type="list",aliases=['objprivs']),
             directory_privs   = dict(default=None, type="list",aliases=['dirprivs']),
             grants_mode   = dict(default="enforce", choices=["append", "enforce"],aliases=['privs_mode']),
             container     = dict(default=None),
@@ -572,6 +527,7 @@ def main():
         mutually_exclusive=[['schema', 'role']]
     )
 
+    oracle_home = module.params["oracle_home"]
     hostname = module.params["hostname"]
     port = module.params["port"]
     service_name = module.params["service_name"]
@@ -580,98 +536,50 @@ def main():
     mode = module.params["mode"]
     schema = module.params["schema"]
     role = module.params["role"]
-    grants = module.params["grants"]
+    system_grants = module.params["grants"]
     object_privs = module.params["object_privs"]
     directory_privs = module.params["directory_privs"]
     grants_mode = module.params["grants_mode"]
     container = module.params["container"]
     state = module.params["state"]
 
-
-
     if not cx_oracle_exists:
-        module.fail_json(msg="The cx_Oracle module is required. 'pip install cx_Oracle' should do the trick. If cx_Oracle is installed, make sure ORACLE_HOME & LD_LIBRARY_PATH is set")
+        module.fail_json(msg="The cx_Oracle module is required. 'pip install cx_Oracle' should do the trick. If cx_Oracle is installed, make sure ORACLE_HOME is set")
 
-    wallet_connect = '/@%s' % service_name
-    try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
-            if mode == 'sysdba':
-                connect = wallet_connect
-                conn = cx_Oracle.connect(wallet_connect, mode=cx_Oracle.SYSDBA)
-            else:
-                connect = wallet_connect
-                conn = cx_Oracle.connect(wallet_connect)
-
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = cx_Oracle.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = cx_Oracle.connect(user, password, dsn, mode=cx_Oracle.SYSDBA)
-            else:
-                dsn = cx_Oracle.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = cx_Oracle.connect(user, password, dsn)
-
-        elif (not(user) or not(password)):
-            module.fail_json(msg='Missing username or password for cx_Oracle')
-
-    except cx_Oracle.DatabaseError as exc:
-        error, = exc.args
-        msg = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
-        module.fail_json(msg=msg, changed=False)
-
+    conn = oracle_connect(module)
     cursor = conn.cursor()
 
     if state == 'present' and schema:
-        if check_user_exists(module, msg, cursor, schema):
-            if ensure_grants(module, msg, cursor, schema, grants, object_privs, directory_privs, grants_mode, container):
-                #msg = 'The grant(s) (%s) have been added to %s successfully' % (grants, schema)
-                module.exit_json(msg=msg, changed=True)
-            else:
-                module.fail_json(msg=msg, changed=False)
-        else:
-            msg = 'Schema %s doesn\'t exist' % (schema)
-            module.fail_json(msg=msg, changed=False)
+        check_user_exists(module, msg, cursor, schema)
+        ensure_grants(module, msg, cursor, schema, system_grants, object_privs, directory_privs, grants_mode, container)
 
     elif state == 'present' and role:
-        if check_role_exists(module, msg, cursor, role):
-            ensure_grants(module, msg, cursor, role, grants, object_privs,directory_privs, grants_mode, container)
-                #msg = 'The grant(s) (%s) have been added to %s successfully' % (grants, schema)
-            module.exit_json(msg=msg, changed=False)
-            # else:
-            #     module.fail_json(msg=msg, changed=False)
-        else:
-            msg = 'Role %s doesn\'t exist' % (role)
-            module.fail_json(msg=msg, changed=False)
+        check_role_exists(module, msg, cursor, role)
+        ensure_grants(module, msg, cursor, role, system_grants, object_privs, directory_privs, grants_mode, container)
 
     elif (state == 'absent' or state == 'REMOVEALL') and schema:
-        #module.exit_json(msg='absent & schema', changed=False)
-        if check_user_exists(module, msg, cursor, schema):
-            if remove_grants(module, msg, cursor, schema, grants, state):
-                #msg = 'The schema %s has been dropped successfully' % schema
-                module.exit_json(msg=msg, changed=True)
+        check_user_exists(module, msg, cursor, schema)
+        if state == 'REMOVEALL':
+            remove_grants(module, msg, cursor, schema, None, None, None, state)
         else:
-            module.exit_json(msg='The schema (%s) doesn\'t exist' % schema, changed=False)
+            remove_grants(module, msg, cursor, schema, system_grants, object_privs, directory_privs, state)
 
     elif (state == 'absent' or state == 'REMOVEALL') and role:
-        #module.exit_json(msg='absent & role', changed=False)
-        if check_role_exists(module, msg, cursor, role):
-            if remove_grants(module, msg, cursor, role, grants, state):
-                #msg = 'The schema %s has been dropped successfully' % schema
-                module.exit_json(msg=msg, changed=True)
-        else:
-            module.exit_json(msg='The role (%s) doesn\'t exist' % role, changed=False)
+        check_role_exists(module, msg, cursor, role)
+        remove_grants(module, msg, cursor, role, system_grants, object_privs, directory_privs, state)
+        #module.exit_json(msg=msg, changed=True)
+        #else:
+        #module.exit_json(msg='The role (%s) doesn\'t exist' % role, changed=False)
+
     else:
         module.fail_json(msg='Missing schema or role', changed=False)
 
-
-    module.fail_json(msg='Unknown object', changed=False)
-
-
-
-
+    module.fail_json(msg='Unknown object - should never be reached', changed=False)
 
 
 from ansible.module_utils.basic import *
+from oracle_utils import oracle_connect
+from collections import namedtuple
+
 if __name__ == '__main__':
     main()

--- a/oracle_user
+++ b/oracle_user
@@ -222,9 +222,10 @@ def modify_user(module, cursor, schema, schema_password, schema_password_hash, d
 	sql_get_curr_def = 'select lower(account_status) as account_status'
 	sql = 'alter user %s' % schema
 
+	old_pw_hash = get_user_password_hash(module, cursor, schema)
 	if update_password == 'always':
 		if authentication_type == 'password':
-			if schema_password_hash:
+			if schema_password_hash and schema_password_hash != old_pw_hash:
 				sql += ''' identified by values '%s' ''' % (schema_password_hash)
 			elif schema_password:
 				sql += ''' identified by "%s" ''' % (schema_password)

--- a/oracle_user
+++ b/oracle_user
@@ -249,82 +249,61 @@ def modify_user(module, cursor, schema, schema_password, schema_password_hash, d
 		sql += ' profile %s ' % profile
 		sql_get_curr_def += ' ,lower(profile) as profile'
 
-	want_account_status = ''
+	want_account_status = None
 	if state == 'present' or state == 'unlocked':
-		want_account_status = 'open'
+		want_account_status = ('ACCOUNT_STATUS', 'open')
 		sql += ' account unlock'
 
 	elif state == 'locked':
-		want_account_status = state
+		want_account_status = ('ACCOUNT_STATUS', state.lower())
 		sql += ' account lock'
 
 	elif state == 'expired':
-		want_account_status = state
+		want_account_status = ('ACCOUNT_STATUS', state.lower())
 		sql += ' password expire'
 
 	elif state == 'expired & locked':
-		want_account_status = state
+		want_account_status = ('ACCOUNT_STATUS', state.lower())
 		sql += ' account lock password expire'
 
-
-	wanted_list = []
-	wanted_list.append(want_account_status)
+	wanted_set = set()
+	if want_account_status:
+		wanted_set.add(want_account_status)
 
 	if authentication_type != 'password' and update_password == 'always':
-		wanted_list.append(authentication_type)
+		wanted_set.add(('AUTHENTICATION_TYPE', authentication_type.lower()))
 
 	if default_tablespace:
-		wanted_list.append(default_tablespace)
+		wanted_set.add(('DEFAULT_TABLESPACE', default_tablespace.lower()))
 
 	if default_temp_tablespace:
-		wanted_list.append(default_temp_tablespace)
+		wanted_set.add(('TEMPORARY_TABLESPACE', default_temp_tablespace.lower()))
 
 	if profile:
-		wanted_list.append(profile)
+		wanted_set.add(('PROFILE', profile.lower()))
 
 	sql_get_curr_def += ' from dba_users where username = upper(\'%s\')' % schema
 
-	if update_password == 'always':
-		old_pw_hash = get_user_password_hash(module, cursor, schema)
+	current_set = execute_sql_get_as_set(module, cursor, sql_get_curr_def)
 
-	wanted_list = [x.lower() for x in wanted_list]
-	curr_defaults = execute_sql_get(module, cursor, sql_get_curr_def)
-	curr_defaults = [list(t) for t in curr_defaults]
+	if schema_password_hash:
+		current_set.add(('PASSWORD_HASH', old_pw_hash))
+		wanted_set.add(('PASSWORD_HASH', schema_password_hash))
 
-	if (schema_password_hash):
-		if update_password == 'always':
-			# if (wanted_list in curr_defaults) and (old_pw_hash == schema_password_hash):
-			# 	# Everything is kosher, exit changed=False
-			# 	module.exit_json(msg='The schema (%s) is in the intented state' % (schema), changed=False)
-			# else:
-			# 	# Make the change and exit changed=True
-				execute_sql(module, cursor, sql)
-				module.exit_json(msg='Successfully altered the user (%s)' % (schema), changed=True)
-		else:
-			if (wanted_list in curr_defaults):
-				module.exit_json(msg='The schema (%s) is in the intented state' % (schema), changed=False)
-			else:
-				# Make the change and exit changed=Truecontainer = module.params["container"]
-				execute_sql(module, cursor, sql)
-				module.exit_json(msg='Successfully altered the user (%s)' % (schema), changed=True)
+        # update_password == 'always' and plaintext password was provided
+	if update_password == 'always' and schema_password:
+		#module.warn(msg=sql)
+		execute_sql(module, cursor, sql)
+		module.exit_json(msg='Successfully altered the user (%s)' % (schema), changed=True)
+
+        # wanted list is subset of current settings, do not do anything
+	if wanted_set.issubset(current_set):
+		module.exit_json(msg='The schema (%s) is in the intented state' % (schema), changed=False)
 	else:
-		if (wanted_list in curr_defaults):
-			if update_password == 'always':
-				## DISABLING THE PRE/POST-CHECK
-				# change everything and compare hash pre/post. If same => exit change=False else exit change=True
-				execute_sql(module, cursor, sql)
-				# new_pw_hash = get_user_password_hash(module, cursor, schema)
-				# if new_pw_hash == old_pw_hash:
-				# 	module.exit_json(msg='The schema (%s) is in the intented state' % (schema), changed=False)
-				# else:
-				module.exit_json(msg='Successfully altered the user (%s)' % (schema), changed=True)
-			else:
-				 module.exit_json(msg='The schema (%s) is in the intented state' % (schema), changed=False)
-		else:
-			# do the complete change -> exit with change=True
-			# module.exit_json(msg=sql)
-			execute_sql(module, cursor, sql)
-			module.exit_json(msg='Successfully altered the user (%s, %s)' % (schema, sql), changed=True)
+		# do the complete change -> exit with change=True
+		# module.warn(msg=sql)
+		execute_sql(module, cursor, sql)
+		module.exit_json(msg='Successfully altered the user (%s) / %s => %s' % (schema,str(current_set),str(wanted_set)), changed=True)
 
 	return True
 
@@ -353,6 +332,22 @@ def execute_sql_get(module, cursor, sql):
 	return result
 
 
+def execute_sql_get_as_set(module, cursor, sql):
+
+	try:
+			cursor.execute(sql)
+			columns = [column[0] for column in cursor.description]
+			results = set()
+			for row in cursor.fetchall():		
+				results.update(set(zip(columns, row)))
+	except cx_Oracle.DatabaseError as exc:
+			error, = exc.args
+			msg = error.message+ ': sql: ' + sql
+			module.fail_json(msg=msg)
+
+	return results
+
+
 # Drop the user
 def drop_user(module, cursor, schema):
 	black_list = ['sys','system','dbsnmp']
@@ -362,6 +357,8 @@ def drop_user(module, cursor, schema):
 	   return False
 
 	sql = 'drop user %s cascade' % schema
+
+	#module.warn(msg=sql)
 
 	try:
 		cursor.execute(sql)

--- a/oracle_user
+++ b/oracle_user
@@ -162,7 +162,7 @@ def create_user(module, cursor, schema, schema_password, schema_password_hash, d
 		if (schema_password_hash):
 			sql = '''create user %s identified by values '%s' ''' % (schema, schema_password_hash)
 		else:
-			sql = 'create user %s identified by \"%s\" '% (schema, schema_password)
+			sql = '''create user %s identified by "%s" ''' % (schema, schema_password)
 	elif authentication_type == 'global':
 		sql = 'create user %s identified globally ' % (schema)
 	elif authentication_type == 'external':
@@ -225,9 +225,9 @@ def modify_user(module, cursor, schema, schema_password, schema_password_hash, d
 	if update_password == 'always':
 		if authentication_type == 'password':
 			if schema_password_hash:
-				sql += ' identified by values \'%s\'' % (schema_password_hash)
+				sql += ''' identified by values '%s' ''' % (schema_password_hash)
 			elif schema_password:
-				sql += ' identified by %s ' % (schema_password)
+				sql += ''' identified by "%s" ''' % (schema_password)
 		elif authentication_type == 'external':
 			sql += ' identified externally '
 			sql_get_curr_def += ' ,lower(authentication_type)'

--- a/oracle_user
+++ b/oracle_user
@@ -219,7 +219,7 @@ def get_user_password_hash(module, cursor, schema):
 # Modify the user/schema
 def modify_user(module, cursor, schema, schema_password, schema_password_hash, default_tablespace, default_temp_tablespace, update_password, profile, authentication_type, state, container_data):
 
-	sql_get_curr_def = 'select lower(account_status)'
+	sql_get_curr_def = 'select lower(account_status) as account_status'
 	sql = 'alter user %s' % schema
 
 	if update_password == 'always':
@@ -230,23 +230,23 @@ def modify_user(module, cursor, schema, schema_password, schema_password_hash, d
 				sql += ''' identified by "%s" ''' % (schema_password)
 		elif authentication_type == 'external':
 			sql += ' identified externally '
-			sql_get_curr_def += ' ,lower(authentication_type)'
+			sql_get_curr_def += ' ,lower(authentication_type) as authentication_type'
 		elif authentication_type == 'global':
 			sql += ' identified globally '
-			sql_get_curr_def += ' ,lower(authentication_type)'
+			sql_get_curr_def += ' ,lower(authentication_type) as authentication_type'
 
 	if default_tablespace:
 		sql += ' default tablespace %s' % default_tablespace
 		sql += ' quota unlimited on %s '% default_tablespace
-		sql_get_curr_def += ' ,lower(default_tablespace)'
+		sql_get_curr_def += ' ,lower(default_tablespace) as default_tablespace'
 
 	if default_temp_tablespace:
 		sql += ' temporary tablespace %s ' % default_temp_tablespace
-		sql_get_curr_def += ' ,lower(temporary_tablespace)'
+		sql_get_curr_def += ' ,lower(temporary_tablespace) as temporary_tablespace'
 
 	if profile:
 		sql += ' profile %s ' % profile
-		sql_get_curr_def += ' ,lower(profile)'
+		sql_get_curr_def += ' ,lower(profile) as profile'
 
 	want_account_status = ''
 	if state == 'present' or state == 'unlocked':

--- a/oracle_user
+++ b/oracle_user
@@ -378,7 +378,7 @@ def main():
 		argument_spec = dict(
 			oracle_home   = dict(required=False, aliases=['oh']),
 			hostname      = dict(default='localhost'),
-			port          = dict(default=1521),
+			port          = dict(default=1521, type="int"),
 			service_name  = dict(required=True, aliases = ['tns']),
 			user          = dict(required=False),
 			password      = dict(required=False, no_log=True),

--- a/oracle_user
+++ b/oracle_user
@@ -160,7 +160,7 @@ def create_user(module, cursor, schema, schema_password, schema_password_hash, d
 
 	if authentication_type == 'password':
 		if (schema_password_hash):
-			sql = 'create user %s identified by values \"%s\" ' % (schema, schema_password_hash)
+			sql = '''create user %s identified by values '%s' ''' % (schema, schema_password_hash)
 		else:
 			sql = 'create user %s identified by \"%s\" '% (schema, schema_password)
 	elif authentication_type == 'global':


### PR DESCRIPTION
Changes summary:
- use single quotes for IDENTIFIED BY VALUES
- user double quotes for IDENTIFIED BY "plaintext password", allows passwords starting with digit (and other special cases)
- upper/lower case for TBS, PROFILE, etc is ignored
- wanted/current are stored as a set of tuples:

      set({('PASSWORD_HASH', '********'), ('PROFILE', 'default'), ('DEFAULT_TABLESPACE', 'users'), ('ACCOUNT_STATUS', 'locked')})

- ALTER USER command is triggered when wanted_set **is not** subset of current_set
- When password hash is provided and is it the same as old password hash, password *is not* altered. This avoids messing with various security profiles.
- port number parameter type is "int"